### PR TITLE
I add some action to the button change_passwrod

### DIFF
--- a/lib/home/profile/account/account_settings.dart
+++ b/lib/home/profile/account/account_settings.dart
@@ -46,8 +46,8 @@ class _AccountSettingsState extends State<AccountSettings> {
           itemBuilder: (_, index) => switch (index) {
             0 => Column(children: [...AccountField.values, saveButton]),
             1 => ListTile(
-                leading: Icon(Icons.lock_outline),
-                title: Text('change password'),
+                leading: const Icon(Icons.lock_outline),
+                title: const Text('change password'),
                 onTap: () => navigator.showDialog(
                   AlertDialog.adaptive(
                     title: const Text('Change Password'),
@@ -56,18 +56,13 @@ class _AccountSettingsState extends State<AccountSettings> {
                       "You'll need to enter your current password & new password to change.",
                     ),
                     actions: [
+                      ElevatedButton(onPressed: navigator.pop, child: const Text('No')),
                       ElevatedButton(
-                          onPressed: navigator.pop, child: const Text('No')),
-                      ElevatedButton(
-                          onPressed: () {
-                            Navigator.of(context).pop();
-                            Navigator.of(context).push(
-                              MaterialPageRoute(
-                                  builder: (context) =>
-                                      const ChangePasswordScreen()),
-                            );
-                          },
-                          child: const Text('Yes')),
+                        onPressed: () => navigator
+                          ..pop()
+                          ..push(const ChangePasswordScreen()),
+                        child: const Text('Yes'),
+                      ),
                     ],
                     actionsAlignment: MainAxisAlignment.spaceEvenly,
                   ),
@@ -84,11 +79,8 @@ class _AccountSettingsState extends State<AccountSettings> {
                       "You'll need to enter your email & password to sign back in.",
                     ),
                     actions: [
-                      ElevatedButton(
-                          onPressed: navigator.pop, child: const Text('back')),
-                      ElevatedButton(
-                          onPressed: navigator.logout,
-                          child: const Text('sign out')),
+                      ElevatedButton(onPressed: navigator.pop, child: const Text('back')),
+                      ElevatedButton(onPressed: navigator.logout, child: const Text('sign out')),
                     ],
                     actionsAlignment: MainAxisAlignment.spaceEvenly,
                   ),

--- a/lib/home/profile/account/account_settings.dart
+++ b/lib/home/profile/account/account_settings.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:thc/firebase/firebase.dart';
 import 'package:thc/home/profile/account/account_field.dart';
+import 'package:thc/home/profile/account/change_password.dart';
 import 'package:thc/home/profile/account/close_account.dart';
 import 'package:thc/home/profile/profile.dart';
 import 'package:thc/utils/navigator.dart';
@@ -44,10 +45,33 @@ class _AccountSettingsState extends State<AccountSettings> {
           itemCount: 4,
           itemBuilder: (_, index) => switch (index) {
             0 => Column(children: [...AccountField.values, saveButton]),
-            1 => const ListTile(
+            1 => ListTile(
                 leading: Icon(Icons.lock_outline),
                 title: Text('change password'),
-                // onTap: () {},
+                onTap: () => navigator.showDialog(
+                  AlertDialog.adaptive(
+                    title: const Text('Change Password'),
+                    content: const Text(
+                      'Are you sure you want to change the password?\n'
+                      "You'll need to enter your current password & new password to change.",
+                    ),
+                    actions: [
+                      ElevatedButton(
+                          onPressed: navigator.pop, child: const Text('No')),
+                      ElevatedButton(
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                  builder: (context) =>
+                                      const ChangePasswordScreen()),
+                            );
+                          },
+                          child: const Text('Yes')),
+                    ],
+                    actionsAlignment: MainAxisAlignment.spaceEvenly,
+                  ),
+                ),
               ),
             2 => ListTile(
                 leading: const Icon(Icons.logout),
@@ -60,8 +84,11 @@ class _AccountSettingsState extends State<AccountSettings> {
                       "You'll need to enter your email & password to sign back in.",
                     ),
                     actions: [
-                      ElevatedButton(onPressed: navigator.pop, child: const Text('back')),
-                      ElevatedButton(onPressed: navigator.logout, child: const Text('sign out')),
+                      ElevatedButton(
+                          onPressed: navigator.pop, child: const Text('back')),
+                      ElevatedButton(
+                          onPressed: navigator.logout,
+                          child: const Text('sign out')),
                     ],
                     actionsAlignment: MainAxisAlignment.spaceEvenly,
                   ),

--- a/lib/home/profile/account/change_password.dart
+++ b/lib/home/profile/account/change_password.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ChangePasswordScreen extends StatelessWidget {
+  const ChangePasswordScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Change Password'),
+      ),
+      body: const Center(
+        child: Text('Change password page put here'),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,6 @@ import 'package:thc/utils/bloc.dart';
 import 'package:thc/utils/keyboard_shortcuts.dart';
 import 'package:thc/utils/local_storage.dart';
 import 'package:thc/utils/navigator.dart';
-import 'package:thc/utils/style_text.dart';
 import 'package:thc/utils/theme.dart';
 
 void main() async {


### PR DESCRIPTION
What I did was add an action to the button for Change_Password, which is in the direction of lib/home/profile/account/account_settings.dart. This button will navigate to the page "change_password.dart," which is in the same direction. "change_password.dart" is a new file I created to check that the navigator works well. Since we still do not have the page for changing passwords,  I just let the page stay blank. Once we have the page, we can put it in this file.