### PR TITLE
Add authentication to "close account" button

### DIFF
--- a/lib/firebase/firebase_auth.dart
+++ b/lib/firebase/firebase_auth.dart
@@ -54,9 +54,12 @@ Future<String?> signIn() async {
       'invalid-password' =>
         'Invalid Password. Please enter password if blank.',
       'invalid-email' => 'Invalid Email. Please enter email if blank.',
+      'unknown-error' => '',
       _ => 'Error: ${e.code}',
     };
   }
+  if (LocalStorage.loggedIn()) return null;
+
   if (LocalStorage.userId() case final id?) {
     if (useInternet) {
       user = await ThcUser.download(id);

--- a/lib/home/profile/account/close_account.dart
+++ b/lib/home/profile/account/close_account.dart
@@ -32,17 +32,14 @@ class _CloseAccountState extends State<CloseAccount> {
         TextField(
           obscureText: _obscureText,
           onChanged: (value) async {
-            final correctValue =
-                await context.read<_Deleting>().checkPassword(value);
-            if (canDelete != correctValue)
-              setState(() => canDelete = correctValue);
+            final correctValue = await context.read<_Deleting>().checkPassword(value);
+            if (canDelete != correctValue) setState(() => canDelete = correctValue);
           },
           onSubmitted: canDelete ? (_) => delete() : null,
           decoration: InputDecoration(
             hintText: 'Enter your password',
             suffixIcon: IconButton(
-              icon:
-                  Icon(_obscureText ? Icons.visibility : Icons.visibility_off),
+              icon: Icon(_obscureText ? Icons.visibility : Icons.visibility_off),
               onPressed: () {
                 setState(() {
                   _obscureText = !_obscureText;
@@ -62,8 +59,7 @@ class _CloseAccountState extends State<CloseAccount> {
         child: switch (progress) {
           _Progress.notStarted => textFieldContent,
           _Progress.loading => _Loading(textFieldContent),
-          _Progress.done =>
-            const Text('You have successfully closed your account.'),
+          _Progress.done => const Text('You have successfully closed your account.'),
         },
       ),
       actions: [
@@ -71,8 +67,7 @@ class _CloseAccountState extends State<CloseAccount> {
           _ConfirmButton('OK', navigator.logout, key: const Key('confirm'))
         else ...[
           _ConfirmButton('Cancel', navigator.pop),
-          _ConfirmButton('Confirm', canDelete ? delete : null,
-              key: const Key('confirm')),
+          _ConfirmButton('Confirm', canDelete ? delete : null, key: const Key('confirm')),
         ],
       ],
     );
@@ -104,8 +99,7 @@ class _ConfirmButton extends StatelessWidget {
 
     return ElevatedButton(
       onPressed: onPressed,
-      child: AnimatedSize(
-          duration: Durations.medium1, curve: Curves.ease, child: Text(text)),
+      child: AnimatedSize(duration: Durations.medium1, curve: Curves.ease, child: Text(text)),
     );
   }
 }
@@ -139,8 +133,7 @@ class _Deleting extends ValueNotifier<_Progress> {
 
   Future<bool> checkPassword(String inputPassword) async {
     // Replace this with the actual logic to verify the user's password
-    final storedPassword =
-        await getUserPassword(); // Fetch the actual user password
+    final storedPassword = await getUserPassword(); // Fetch the actual user password
     return inputPassword == storedPassword;
   }
 


### PR DESCRIPTION
Hello, I changed the pre-function of the delete user button, which means that I first let the user enter the password, and then when the user enters the password, a variable will get the user password from Firebase. When the password entered by the user is consistent with this variable, the button will become available, and then the account can be deleted. If the user input and password are inconsistent, the account cannot be deleted, and I added a button that can show or hide the password entered by the user.