### PR TITLE
Change password

### DIFF
--- a/lib/home/profile/account/account_settings.dart
+++ b/lib/home/profile/account/account_settings.dart
@@ -48,25 +48,8 @@ class _AccountSettingsState extends State<AccountSettings> {
             1 => ListTile(
                 leading: const Icon(Icons.lock_outline),
                 title: const Text('change password'),
-                onTap: () => navigator.showDialog(
-                  AlertDialog.adaptive(
-                    title: const Text('Change Password'),
-                    content: const Text(
-                      'Are you sure you want to change the password?\n'
-                      "You'll need to enter your current password & new password to change.",
-                    ),
-                    actions: [
-                      ElevatedButton(onPressed: navigator.pop, child: const Text('No')),
-                      ElevatedButton(
-                        onPressed: () => navigator
-                          ..pop()
-                          ..push(const ChangePasswordScreen()),
-                        child: const Text('Yes'),
-                      ),
-                    ],
-                    actionsAlignment: MainAxisAlignment.spaceEvenly,
-                  ),
-                ),
+                onTap: () => Navigator.of(context).push(MaterialPageRoute(
+                    builder: (_) => const ChangePasswordScreen())),
               ),
             2 => ListTile(
                 leading: const Icon(Icons.logout),
@@ -79,8 +62,11 @@ class _AccountSettingsState extends State<AccountSettings> {
                       "You'll need to enter your email & password to sign back in.",
                     ),
                     actions: [
-                      ElevatedButton(onPressed: navigator.pop, child: const Text('back')),
-                      ElevatedButton(onPressed: navigator.logout, child: const Text('sign out')),
+                      ElevatedButton(
+                          onPressed: navigator.pop, child: const Text('back')),
+                      ElevatedButton(
+                          onPressed: navigator.logout,
+                          child: const Text('sign out')),
                     ],
                     actionsAlignment: MainAxisAlignment.spaceEvenly,
                   ),

--- a/lib/home/profile/account/change_password.dart
+++ b/lib/home/profile/account/change_password.dart
@@ -1,17 +1,203 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:thc/utils/navigator.dart';
 
-class ChangePasswordScreen extends StatelessWidget {
+class ChangePasswordScreen extends StatefulWidget {
   const ChangePasswordScreen({super.key});
+
+  @override
+  // ignore: library_private_types_in_public_api
+  _ChangePasswordScreenState createState() => _ChangePasswordScreenState();
+}
+
+class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
+  final TextEditingController _currentPasswordController =
+      TextEditingController();
+  final TextEditingController _newPasswordController = TextEditingController();
+  final TextEditingController _confirmPasswordController =
+      TextEditingController();
+  bool _isCurrentPasswordCorrect = false;
+
+  // Delete from here
+  bool _isTestingMode = false;
+  // to here
+
+  @override
+  void initState() {
+    super.initState();
+    _currentPasswordController.addListener(_validateCurrentPassword);
+  }
+
+  void _validateCurrentPassword() async {
+    // Delete from here
+    if (_isTestingMode) {
+      setState(() => _isCurrentPasswordCorrect = true);
+      return;
+    }
+    // to here
+
+    final user = FirebaseAuth.instance.currentUser;
+    final cred = EmailAuthProvider.credential(
+      email: user!.email!,
+      password: _currentPasswordController.text,
+    );
+
+/*
+    try {
+      await user.reauthenticateWithCredential(cred);
+      setState(() => _isCurrentPasswordCorrect = true);
+    } catch (e) {
+      setState(() => _isCurrentPasswordCorrect = false);
+    }
+  }
+*/
+
+    // Delete from here
+    try {
+      await user.reauthenticateWithCredential(cred);
+      if (mounted) {
+        setState(() => _isCurrentPasswordCorrect = true);
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _isCurrentPasswordCorrect = false);
+      }
+    }
+  }
+  // to here
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Change Password'),
+        // Delete from here
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(_isTestingMode ? Icons.toggle_on : Icons.toggle_off),
+            onPressed: () => setState(() => _isTestingMode = !_isTestingMode),
+          ),
+        ],
+        // to here
       ),
-      body: const Center(
-        child: Text('Change password page put here'),
+      body: Center(
+        child: Container(
+          padding: const EdgeInsets.all(16.0),
+          width: 500,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildPasswordField(
+                controller: _currentPasswordController,
+                labelText: 'Current Password',
+                isCorrect: _isCurrentPasswordCorrect,
+              ),
+              const SizedBox(height: 30),
+              _buildPasswordField(
+                controller: _newPasswordController,
+                labelText: 'New Password',
+                enabled: _isCurrentPasswordCorrect,
+              ),
+              _buildPasswordField(
+                controller: _confirmPasswordController,
+                labelText: 'Confirm New Password',
+                enabled: _isCurrentPasswordCorrect,
+              ),
+              ElevatedButton(
+                onPressed: _isCurrentPasswordCorrect ? _changePassword : null,
+                child: const Text('Change Password'),
+              ),
+            ],
+          ),
+        ),
       ),
     );
+  }
+
+  Widget _buildPasswordField({
+    required TextEditingController controller,
+    required String labelText,
+    bool isCorrect = false,
+    bool enabled = true,
+  }) {
+    return TextField(
+      controller: controller,
+      obscureText: true,
+      enabled: enabled,
+      decoration: InputDecoration(
+        labelText: labelText,
+        labelStyle: const TextStyle(color: Colors.black),
+        suffixIcon: controller == _currentPasswordController
+            ? Icon(
+                isCorrect ? Icons.check : Icons.close,
+                color: isCorrect ? Colors.green : Colors.red,
+              )
+            : null,
+      ),
+    );
+  }
+
+  void _changePassword() async {
+    if (_newPasswordController.text == _confirmPasswordController.text) {
+      final User? user = FirebaseAuth.instance.currentUser;
+      final String newPassword = _newPasswordController.text;
+
+      try {
+        await user?.updatePassword(newPassword);
+        showDialog(
+          context: context,
+          builder: (context) {
+            return AlertDialog(
+              title: const Text('Password Changed'),
+              content:
+                  const Text('Your password has been successfully changed.'),
+              actions: <Widget>[
+                TextButton(
+                  child: const Text('OK'),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    navigator.logout();
+                  },
+                ),
+              ],
+            );
+          },
+        );
+      } catch (e) {
+        showDialog(
+          context: context,
+          builder: (context) {
+            return AlertDialog(
+              title: const Text('Failed to Change Password'),
+              content: Text('Failed to change password: $e'),
+              actions: <Widget>[
+                TextButton(
+                  child: const Text('OK'),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            );
+          },
+        );
+      }
+    } else {
+      showDialog(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('Password Mismatch'),
+            content:
+                const Text('The passwords do not match. Please try again.'),
+            actions: <Widget>[
+              TextButton(
+                child: const Text('OK'),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+            ],
+          );
+        },
+      );
+    }
   }
 }

--- a/lib/home/profile/account/close_account.dart
+++ b/lib/home/profile/account/close_account.dart
@@ -29,8 +29,9 @@ class _CloseAccountState extends StateAsync<CloseAccount> {
             await LocalStorage.password.save(password);
             if (await auth.signIn() case final error?) {
               return safeState(() {
-                errorText =
-                    error.isEmpty ? 'please double-check your password and try again.' : error;
+                errorText = error.isEmpty
+                    ? 'please double-check your password and try again.'
+                    : error;
               });
             }
 
@@ -42,7 +43,7 @@ class _CloseAccountState extends StateAsync<CloseAccount> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Text(
-          'To confirm deletion, please type "DELETE" in the field below and tap "Confirm".',
+          'To confirm deletion, please type your password in the field below and tap "Confirm".',
           style: StyleText(size: 16),
         ),
         TextField(
@@ -74,7 +75,8 @@ class _CloseAccountState extends StateAsync<CloseAccount> {
         child: switch (progress) {
           _Progress.notStarted => textFieldContent,
           _Progress.loading => _Loading(textFieldContent),
-          _Progress.done => const Text('You have successfully closed your account.'),
+          _Progress.done =>
+            const Text('You have successfully closed your account.'),
         },
       ),
       actions: [
@@ -114,7 +116,8 @@ class _ConfirmButton extends StatelessWidget {
 
     return ElevatedButton(
       onPressed: onPressed,
-      child: AnimatedSize(duration: Durations.medium1, curve: Curves.ease, child: Text(text)),
+      child: AnimatedSize(
+          duration: Durations.medium1, curve: Curves.ease, child: Text(text)),
     );
   }
 }


### PR DESCRIPTION
I changed the prompt statement for closing the dialog box in the account. I forgot to change it before. 
Then I deleted the dialog box that pops up in the account interface when I click to change password, asking the user if they want to enter, because when I enter the change password page, the return key in the Appbar can only go back to the previous step, and this will still appear dialog box of before. I think the this step can be optimized here, so I deleted it directly.So now when we click the button will enter the password change page directly, without dialog box. 
Then I created a complete password change interface. Although its UI looks ugly right now, we can optimize the UI later and I have achieved the basic functions required. First, in the first line, verify whether the user's input is consistent with the password in firebase. If they are consistent, a green check will be displayed. When the verification is completed, the nexts will be unlocked. Before that, the nexts column is unavailable. Then when the new passwords entered in the second and third lines are consistent, click the change password button, and the password will be updated in firebase in the background. If they are inconsistent, an inconsistent password will pop up after clicking the button, please re-enter.
There is another question. Regarding the format, every time my VS code is saved, it will automatically change the format of each line to make them look neater, such as line breaks. I cannot control this, but the content is still the same.